### PR TITLE
Added virtual destructor

### DIFF
--- a/src/state.hpp
+++ b/src/state.hpp
@@ -4,6 +4,7 @@
 namespace kg {
     class State {
     public:
+        virtual ~State() { }
         virtual void init() = 0;
 
         virtual void handleInput() = 0;


### PR DESCRIPTION
Added virtual destructor to releases ressources created by child classes (game states).
Resources were not released when _states.pop() was called in state_machine.cpp.

I noted that memory consumption was increasing every time a new GameState was added.
This modification allows also to free memory for smart pointers created in child classes whadn cgame state in poped.  